### PR TITLE
 Build: Fix compile time warnings 

### DIFF
--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -1923,7 +1923,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/examples/example/platformio.ini
+++ b/examples/example/platformio.ini
@@ -26,7 +26,7 @@ lib_deps =
     ArduinoNative
     HAL
     Webots
-    https://github.com/BlueAndi/ZumoHALWebots
+    BlueAndi/ZumoHALWebots @ ~0.2.0
 extra_scripts =
     pre:$PROJECT_LIBDEPS_DIR/$PIOENV/ZumoHALWebots/scripts/create_webots_library.py
     pre:$PROJECT_LIBDEPS_DIR/$PIOENV/ZumoHALWebots/scripts/copy_sounds.py

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "ZumoHALWebots",
-    "version": "0.1.2",
+    "version": "0.2.0",
     "description": "Zumo C++ hardware abstraction layer for the Webots simulation.",
     "authors": [{
         "name": "Andreas Merkle",
@@ -12,7 +12,7 @@
     "dependencies": [{
         "owner": "BlueAndi",
         "name": "ZumoHALInterfaces",
-        "version": "~0.1.1"
+        "version": "~0.2.0"
     }, {
         "owner": "bblanchon",
         "name": "ArduinoJson",

--- a/src/IMU.cpp
+++ b/src/IMU.cpp
@@ -108,7 +108,7 @@ void IMU::readMagnetometer()
     }
 }
 
-const void IMU::getAccelerationValues(IMUData* accelerationValues)
+void IMU::getAccelerationValues(IMUData* accelerationValues) const
 {
     if (nullptr != accelerationValues)
     {
@@ -118,7 +118,7 @@ const void IMU::getAccelerationValues(IMUData* accelerationValues)
     }
 }
 
-const void IMU::getTurnRates(IMUData* turnRates)
+void IMU::getTurnRates(IMUData* turnRates) const
 {
     if (nullptr != turnRates)
     {
@@ -128,7 +128,7 @@ const void IMU::getTurnRates(IMUData* turnRates)
     }
 }
 
-const void IMU::getMagnetometerValues(IMUData* magnetometerValues)
+void IMU::getMagnetometerValues(IMUData* magnetometerValues) const
 {
     if (nullptr != magnetometerValues)
     {

--- a/src/IMU.h
+++ b/src/IMU.h
@@ -162,7 +162,7 @@ public:
      * x, y and z direction will be written into. The values can be converted into physical values in mm/s^2 via the
      * multiplication with a sensitivity factor in mm/s^2/digit.
      */
-    void const getAccelerationValues(IMUData* accelerationValues) final;
+    void getAccelerationValues(IMUData* accelerationValues) const final;
 
     /**
      * Get last raw Gyro values as an IMUData struct containing values in x, y and z in digits.
@@ -171,7 +171,7 @@ public:
      * direction will be written into. The values can be converted into physical values in mrad/s via the multiplication
      * with a sensitivity factor in mrad/s/digit.
      */
-    void const getTurnRates(IMUData* turnRates) final;
+    void getTurnRates(IMUData* turnRates) const final;
 
     /**
      * Get last raw Magnetometer values as an IMUData struct containing values in x, y and z in digits.
@@ -180,7 +180,7 @@ public:
      * x, y and z direction will be written into. The values can be converted into physical values in mgauss via the
      * multiplication with a sensitivity factor in mgauss/digit.
      */
-    void const getMagnetometerValues(IMUData* magnetometerValues) final;
+    void getMagnetometerValues(IMUData* magnetometerValues) const final;
 
     /**
      * Calibrate the IMU.

--- a/src/Keyboard.h
+++ b/src/Keyboard.h
@@ -64,10 +64,11 @@ public:
     /**
      * Constructs the encoders adapter and initialize it.
      */
-    Keyboard(SimTime &simTime, webots::Keyboard *keyboard) : m_oldKeys(),
-                                                             m_newKeys(),
-                                                             m_simTime(simTime),
-                                                             m_keyboard(keyboard)
+    Keyboard(SimTime &simTime, webots::Keyboard *keyboard) :
+        m_oldKeys(),
+        m_newKeys(),
+        m_simTime(simTime),
+        m_keyboard(keyboard)
     {
     }
 

--- a/src/Keyboard.h
+++ b/src/Keyboard.h
@@ -64,11 +64,10 @@ public:
     /**
      * Constructs the encoders adapter and initialize it.
      */
-    Keyboard(SimTime& simTime, webots::Keyboard* keyboard) :
-        m_oldKeys(),
-        m_newKeys(),
-        m_simTime(simTime),
-        m_keyboard(keyboard)
+    Keyboard(SimTime &simTime, webots::Keyboard *keyboard) : m_oldKeys(),
+                                                             m_newKeys(),
+                                                             m_simTime(simTime),
+                                                             m_keyboard(keyboard)
     {
     }
 
@@ -242,9 +241,9 @@ private:
     /** The keys pressed during this update. */
     uint16_t m_newKeys[MAX_KEY_NUMBER];
 
-    webots::Keyboard* m_keyboard; /**< Robot keyboard */
+    SimTime &m_simTime; /**< Simulation time */
 
-    SimTime& m_simTime; /**< Simulation time */
+    webots::Keyboard *m_keyboard; /**< Robot keyboard */
 
     /**
      * Is the button pressed?

--- a/src/Keyboard.h
+++ b/src/Keyboard.h
@@ -64,7 +64,7 @@ public:
     /**
      * Constructs the encoders adapter and initialize it.
      */
-    Keyboard(SimTime &simTime, webots::Keyboard *keyboard) :
+    Keyboard(SimTime& simTime, webots::Keyboard* keyboard) :
         m_oldKeys(),
         m_newKeys(),
         m_simTime(simTime),

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -58,8 +58,8 @@ static size_t getFileSize(FILE *fd);
  * Local Variables
  *****************************************************************************/
 
-const char* Settings::SETTINGS_FILE_NAME = "settings.json";
-const uint8_t Settings::DATA_VERSION     = 1U;
+const char*   Settings::SETTINGS_FILE_NAME = "settings.json";
+const uint8_t Settings::DATA_VERSION       = 1U;
 
 /******************************************************************************
  * Public Methods
@@ -98,12 +98,12 @@ void Settings::setMaxSpeed(int16_t maxSpeed)
 bool Settings::loadSettings()
 {
     bool isSuccessful = false;
-    FILE *fd          = fopen(SETTINGS_FILE_NAME, "rb");
+    FILE* fd          = fopen(SETTINGS_FILE_NAME, "rb");
 
     if (nullptr != fd)
     {
         size_t fileSize = getFileSize(fd);
-        char buffer[fileSize];
+        char   buffer[fileSize];
 
         if (fileSize == fread(buffer, sizeof(char), fileSize, fd))
         {
@@ -150,7 +150,7 @@ void Settings::saveSettings()
      * the settings!
      */
 
-    jsonDoc["version"] = DATA_VERSION;
+    jsonDoc["version"]  = DATA_VERSION;
     jsonDoc["maxSpeed"] = m_maxSpeed;
 
     jsonBufferSize = measureJsonPretty(jsonDoc); /* Size without string termination. */
@@ -188,7 +188,7 @@ void Settings::saveSettings()
  *
  * @return File size in byte
  */
-static size_t getFileSize(FILE *fd)
+static size_t getFileSize(FILE* fd)
 {
     long current = ftell(fd); /* Remember current position. */
     long begin;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -52,7 +52,7 @@
  * Prototypes
  *****************************************************************************/
 
-static size_t getFileSize(FILE *fd);
+static size_t getFileSize(FILE* fd);
 
 /******************************************************************************
  * Local Variables
@@ -97,8 +97,8 @@ void Settings::setMaxSpeed(int16_t maxSpeed)
 
 bool Settings::loadSettings()
 {
-    bool isSuccessful = false;
-    FILE* fd          = fopen(SETTINGS_FILE_NAME, "rb");
+    bool  isSuccessful = false;
+    FILE* fd           = fopen(SETTINGS_FILE_NAME, "rb");
 
     if (nullptr != fd)
     {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -58,8 +58,8 @@ static size_t getFileSize(FILE *fd);
  * Local Variables
  *****************************************************************************/
 
-const char *Settings::SETTINGS_FILE_NAME = "settings.json";
-const uint8_t Settings::DATA_VERSION = 1U;
+const char* Settings::SETTINGS_FILE_NAME = "settings.json";
+const uint8_t Settings::DATA_VERSION     = 1U;
 
 /******************************************************************************
  * Public Methods
@@ -98,7 +98,7 @@ void Settings::setMaxSpeed(int16_t maxSpeed)
 bool Settings::loadSettings()
 {
     bool isSuccessful = false;
-    FILE *fd = fopen(SETTINGS_FILE_NAME, "rb");
+    FILE *fd          = fopen(SETTINGS_FILE_NAME, "rb");
 
     if (nullptr != fd)
     {
@@ -107,8 +107,8 @@ bool Settings::loadSettings()
 
         if (fileSize == fread(buffer, sizeof(char), fileSize, fd))
         {
-            const size_t JSON_DOC_SIZE = 4096U;
-            DynamicJsonDocument jsonDoc(JSON_DOC_SIZE);
+            const size_t         JSON_DOC_SIZE = 4096U;
+            DynamicJsonDocument  jsonDoc(JSON_DOC_SIZE);
             DeserializationError status = deserializeJson(jsonDoc, buffer);
 
             if (DeserializationError::Ok == status)
@@ -142,9 +142,9 @@ bool Settings::loadSettings()
 
 void Settings::saveSettings()
 {
-    const size_t JSON_DOC_SIZE = 4096U;
+    const size_t        JSON_DOC_SIZE = 4096U;
     DynamicJsonDocument jsonDoc(JSON_DOC_SIZE);
-    size_t jsonBufferSize;
+    size_t              jsonBufferSize;
 
     /* Don't forget to bump the DATA_VERSION every time you modify
      * the settings!
@@ -160,7 +160,7 @@ void Settings::saveSettings()
 
         if (jsonBufferSize == serializeJsonPretty(jsonDoc, jsonBuffer, jsonBufferSize))
         {
-            FILE *fd = fopen(SETTINGS_FILE_NAME, "wb");
+            FILE* fd = fopen(SETTINGS_FILE_NAME, "wb");
 
             if (nullptr != fd)
             {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -52,14 +52,14 @@
  * Prototypes
  *****************************************************************************/
 
-static long getFileSize(FILE* fd);
+static size_t getFileSize(FILE *fd);
 
 /******************************************************************************
  * Local Variables
  *****************************************************************************/
 
-const char*   Settings::SETTINGS_FILE_NAME = "settings.json";
-const uint8_t Settings::DATA_VERSION       = 1U;
+const char *Settings::SETTINGS_FILE_NAME = "settings.json";
+const uint8_t Settings::DATA_VERSION = 1U;
 
 /******************************************************************************
  * Public Methods
@@ -97,18 +97,18 @@ void Settings::setMaxSpeed(int16_t maxSpeed)
 
 bool Settings::loadSettings()
 {
-    bool  isSuccessful = false;
-    FILE* fd           = fopen(SETTINGS_FILE_NAME, "rb");
+    bool isSuccessful = false;
+    FILE *fd = fopen(SETTINGS_FILE_NAME, "rb");
 
     if (nullptr != fd)
     {
-        long fileSize = getFileSize(fd);
+        size_t fileSize = getFileSize(fd);
         char buffer[fileSize];
 
         if (fileSize == fread(buffer, sizeof(char), fileSize, fd))
         {
-            const size_t         JSON_DOC_SIZE = 4096U;
-            DynamicJsonDocument  jsonDoc(JSON_DOC_SIZE);
+            const size_t JSON_DOC_SIZE = 4096U;
+            DynamicJsonDocument jsonDoc(JSON_DOC_SIZE);
             DeserializationError status = deserializeJson(jsonDoc, buffer);
 
             if (DeserializationError::Ok == status)
@@ -142,15 +142,15 @@ bool Settings::loadSettings()
 
 void Settings::saveSettings()
 {
-    const size_t        JSON_DOC_SIZE = 4096U;
+    const size_t JSON_DOC_SIZE = 4096U;
     DynamicJsonDocument jsonDoc(JSON_DOC_SIZE);
-    size_t              jsonBufferSize;
+    size_t jsonBufferSize;
 
     /* Don't forget to bump the DATA_VERSION every time you modify
      * the settings!
      */
 
-    jsonDoc["version"]  = DATA_VERSION;
+    jsonDoc["version"] = DATA_VERSION;
     jsonDoc["maxSpeed"] = m_maxSpeed;
 
     jsonBufferSize = measureJsonPretty(jsonDoc); /* Size without string termination. */
@@ -160,7 +160,7 @@ void Settings::saveSettings()
 
         if (jsonBufferSize == serializeJsonPretty(jsonDoc, jsonBuffer, jsonBufferSize))
         {
-            FILE* fd = fopen(SETTINGS_FILE_NAME, "wb");
+            FILE *fd = fopen(SETTINGS_FILE_NAME, "wb");
 
             if (nullptr != fd)
             {
@@ -188,7 +188,7 @@ void Settings::saveSettings()
  *
  * @return File size in byte
  */
-static long getFileSize(FILE* fd)
+static size_t getFileSize(FILE *fd)
 {
     long current = ftell(fd); /* Remember current position. */
     long begin;
@@ -202,5 +202,5 @@ static long getFileSize(FILE* fd)
     /* Restore position. */
     (void)fseek(fd, current, SEEK_SET);
 
-    return end - begin;
+    return (size_t)(end - begin);
 }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -202,5 +202,5 @@ static size_t getFileSize(FILE* fd)
     /* Restore position. */
     (void)fseek(fd, current, SEEK_SET);
 
-    return (size_t)(end - begin);
+    return static_cast<size_t>(end - begin);
 }


### PR DESCRIPTION
Compiling with -Wall -Wextra results in the following warnings:

    .pio\libdeps\Example\ZumoHALWebots\src/Keyboard.h: In constructor
    'Keyboard::Keyboard(SimTime&, webots::Keyboard*)':
    .pio\libdeps\Example\ZumoHALWebots\src/Keyboard.h:247:14: warning:
    'Keyboard::m_simTime' will be initialized after [-Wreorder]
      247 |     SimTime& m_simTime; /**< Simulation time */

    .pio\libdeps\Example\ZumoHALWebots\src\Settings.cpp: In member function
    'bool Settings::loadSettings()':
    .pio\libdeps\Example\ZumoHALWebots\src\Settings.cpp:108:22: warning:
    comparison of integer expressions of different signedness: 'long int'
    and 'size_t' {aka 'long long unsigned int'} [-Wsign-compare]
      108 |         if (fileSize == fread(buffer, sizeof(char), fileSize,
          fd))