### PR TITLE
Add missing "Contents" directory suffix for webots MacOS installations 

### DIFF
--- a/scripts/copy_webots_shared_libs.py
+++ b/scripts/copy_webots_shared_libs.py
@@ -57,8 +57,8 @@ if OS_PLATFORM_TYPE == OS_PLATFORM_TYPE_WIN:
 elif OS_PLATFORM_TYPE == OS_PLATFORM_TYPE_MACOS:
 
     SHARED_FILES_LIST = [
-        '/lib/controller/libController.dylib',
-        '/lib/controller/libCppController.dylib'
+        '/Contents/lib/controller/libController.dylib',
+        '/Contents/lib/controller/libCppController.dylib'
     ]
 
 elif OS_PLATFORM_TYPE == OS_PLATFORM_TYPE_LINUX:

--- a/scripts/create_webots_library.py
+++ b/scripts/create_webots_library.py
@@ -36,15 +36,19 @@ import platform
 # Variables
 ################################################################################
 
-src_path_include_c      = os.getenv('WEBOTS_HOME') + '/include/controller/c'
-src_path_include_cpp    = os.getenv('WEBOTS_HOME') + '/include/controller/cpp'
-src_path_source         = os.getenv('WEBOTS_HOME') + '/src/controller/cpp'
-src_path_lib            = os.getenv('WEBOTS_HOME') + '/lib/controller/libController'
-
 OS_PLATFORM_TYPE_WIN = "Windows"
 OS_PLATFORM_TYPE_LINUX = "Linux"
 OS_PLATFORM_TYPE_MACOS = "Darwin"
 OS_PLATFORM_TYPE = platform.system()
+
+# On macOS Webots ships as a .app bundle; all paths live under Contents/
+_CONTENTS = '/Contents' if OS_PLATFORM_TYPE == OS_PLATFORM_TYPE_MACOS else ''
+_WEBOTS_HOME = os.getenv('WEBOTS_HOME') + _CONTENTS
+
+src_path_include_c      = _WEBOTS_HOME + '/include/controller/c'
+src_path_include_cpp    = _WEBOTS_HOME + '/include/controller/cpp'
+src_path_source         = _WEBOTS_HOME + '/src/controller/cpp'
+src_path_lib            = _WEBOTS_HOME + '/lib/controller/libController'
 
 #  Add correct file extension for the platform.
 if OS_PLATFORM_TYPE == OS_PLATFORM_TYPE_WIN:


### PR DESCRIPTION
On macOS, Webots is installed as a `.app` bundle. The conventional `WEBOTS_HOME` points to the bundle root (e.g. `/Applications/Webots.app`), but all headers, sources, and libraries reside one level deeper under `Contents/`. The scripts and `library.json` assumed a flat layout, causing `FileNotFoundError` on macOS.

## Changes
- `scripts/create_webots_library.py`: detect macOS and prepend `/Contents` to all paths derived from `WEBOTS_HOME`
- `scripts/copy_webots_shared_libs.py`: same fix for the dylib paths in `SHARED_FILES_LIST`
- `library.json`: fix `-L` flag from `lib/Webots/lib/controller` to `lib/Webots/lib` (the actual directory `create_webots_library.py` copies the dylib into)

**Note:** The `webots-controller` executable will also expect WEBOTS_HOME to simply point to the *.app file and would fails with the following error when adding "Contents/" to the WEBOTS_HOME variable and would fail with this error:
 
```
dyld[5780]: Library not loaded: @rpath/Contents/lib/controller/libController.dylib
  Referenced from: <2029B01F-9D80-3E00-90C0-C23650F528D8> /Users/jhoeft/projects/RadonUlzer/.pio/build/LineFollowerSim/program
  Reason: tried: '/Applications/Webots.app/Contents/Contents/lib/controller/libController.dylib' (no such file), '(null)/libController.dylib' (no such file)
```